### PR TITLE
MAGE-1535 Fixes for v0.4.0

### DIFF
--- a/bin/magento2-analyse
+++ b/bin/magento2-analyse
@@ -30,12 +30,11 @@ fi
 
 printf "${GREEN}Magento root detected:${NC} %s\n\n" "$MAGENTO_ROOT"
 
-# Resolve the vendor directory containing phpstan extensions bundled with magento2-tools.
+# VENDOR_BIN (set by env.sh) already points to the correct bin/ directory for the active
+# install layout. The vendor directory is simply its parent.
 TOOLS_VENDOR_DIR=""
-if [ -d "$LIB_DIR/../vendor" ]; then
-    TOOLS_VENDOR_DIR=$(cd "$LIB_DIR/../vendor" && pwd)
-elif [ -d "$LIB_DIR/../../../vendor" ]; then
-    TOOLS_VENDOR_DIR=$(cd "$LIB_DIR/../../../vendor" && pwd)
+if [ -n "$VENDOR_BIN" ]; then
+    TOOLS_VENDOR_DIR=$(cd "${VENDOR_BIN}.." && pwd)
 fi
 
 # Generate a runtime neon that wires everything together with absolute paths.

--- a/bin/magento2-analyse
+++ b/bin/magento2-analyse
@@ -70,10 +70,12 @@ parameters:
         - $MAGENTO_ROOT/vendor/autoload.php
 NEON
 
+# Run from the extension directory so that any relative paths in the extension's
+# own phpstan.neon resolve correctly, regardless of where the user invoked the script.
 # If the extension provides its own neon config (with paths), let PHPStan use those.
 # Otherwise fall back to scanning the entire extension directory.
 if [ -f "$EXTENSION_DIR/phpstan.neon" ] || [ -f "$EXTENSION_DIR/phpstan.neon.dist" ]; then
-    ${VENDOR_BIN}phpstan analyse --memory-limit=4G -c "$RUNTIME_NEON"
+    (cd "$EXTENSION_DIR" && ${VENDOR_BIN}phpstan analyse --memory-limit=4G -c "$RUNTIME_NEON")
 else
-    ${VENDOR_BIN}phpstan analyse --memory-limit=4G -c "$RUNTIME_NEON" "$EXTENSION_DIR"
+    (cd "$EXTENSION_DIR" && ${VENDOR_BIN}phpstan analyse --memory-limit=4G -c "$RUNTIME_NEON" "$EXTENSION_DIR")
 fi

--- a/bin/magento2-analyse
+++ b/bin/magento2-analyse
@@ -38,7 +38,10 @@ if [ -n "$VENDOR_BIN" ]; then
 fi
 
 # Generate a runtime neon that wires everything together with absolute paths.
-RUNTIME_NEON=$(mktemp /tmp/phpstan-magento2-tools.XXXXXX.neon)
+RUNTIME_NEON=$(mktemp /tmp/phpstan-magento2-tools.XXXXXX)
+mv "$RUNTIME_NEON" "$RUNTIME_NEON.neon"
+RUNTIME_NEON="$RUNTIME_NEON.neon"
+
 trap "rm -f $RUNTIME_NEON" EXIT
 
 # --- Build includes ---

--- a/bin/magento2-update
+++ b/bin/magento2-update
@@ -2,7 +2,7 @@
 
 set -e
 
-CURRENT_VERSION=v0.4.0
+CURRENT_VERSION=v0.4.1
 
 get_latest_release() {
   curl --silent "https://api.github.com/repos/algolia/magento2-tools/releases/latest" | # Get latest release from GitHub api


### PR DESCRIPTION
**Summary**

- **Fixed PHPStan lib path resolution in global installs** - replaced fragile relative directory traversal (`../vendor`, `../../../vendor`) with `VENDOR_BIN` from `env.sh`, which already handles install layout detection
- **Fixed extension-relative path resolution** - PHPStan now runs in a subshell `cd`'d to the extension directory, so relative paths in an extension's own `phpstan.neon` resolve correctly regardless of where the user invokes the script
- **Fixed `mktemp` on macOS** - BSD `mktemp` requires `X` placeholders at the end of the template; the old `.XXXXXX.neon` pattern was treated literally, causing "File exists" errors on repeated runs
- **Bumped version to v0.4.1**

**Testing**

- [x]  Run `magento2-analyse` against a Magento extension in a **global** Composer install layout
- [x]  Run `magento2-analyse` against an extension in a separate path from `pwd`
- [x]  Run `magento2-analyse` twice in a row after a forced failure (verify no `mktemp` collision)
- [x]  Verify temp neon file is cleaned up on successful and failed runs