### PR TITLE
MAGE-1585 Add json format support

### DIFF
--- a/bin/magento2-analyse
+++ b/bin/magento2-analyse
@@ -2,10 +2,13 @@
 
 set -e
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+# shellcheck source=../lib/parse-args.sh
+source "$SCRIPT_DIR/../lib/parse-args.sh"
+
 EXTENSION_DIR=${1?Error: no extension dir given}
 VENDOR_BIN=${2}
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck source=../lib/env.sh
 source "$SCRIPT_DIR/../lib/env.sh"
 # shellcheck source=../lib/detect-magento.sh
@@ -28,15 +31,19 @@ EXTENSION_DIR=$(cd "$EXTENSION_DIR" && pwd)
 
 # Detect Magento root — required for meaningful PHPStan analysis
 if ! detect_magento_root "$EXTENSION_DIR"; then
-    printf "${RED}Error:${NC} Could not detect a Magento root installation.\n"
-    printf "PHPStan requires the full Magento dependency chain to produce useful results.\n"
-    printf "Ensure the extension is installed within a Magento project (e.g. via Composer).\n"
+    printf "${RED}Error:${NC} Could not detect a Magento root installation.\n" 1>&2
+    printf "PHPStan requires the full Magento dependency chain to produce useful results.\n" 1>&2
+    printf "Ensure the extension is installed within a Magento project (e.g. via Composer).\n" 1>&2
     exit 1
 fi
 
 EXTENSION_DIR=$(cd "$EXTENSION_DIR" && pwd -P)
 
-printf "${GREEN}Magento root detected:${NC} %s\n\n" "$MAGENTO_ROOT"
+if [ "$JSON_MODE" = "1" ]; then
+    printf "${GREEN}Magento root detected:${NC} %s\n\n" "$MAGENTO_ROOT" 1>&2
+else
+    printf "${GREEN}Magento root detected:${NC} %s\n\n" "$MAGENTO_ROOT"
+fi
 
 # VENDOR_BIN (set by env.sh) already points to the correct bin/ directory for the active
 # install layout. The vendor directory is simply its parent.
@@ -81,12 +88,19 @@ parameters:
         - $MAGENTO_ROOT/vendor/autoload.php
 NEON
 
+# In JSON mode, swap PHPStan's output to its machine-readable formatter and silence
+# the progress bar (it writes ANSI control codes to stdout and would corrupt JSON).
+PHPSTAN_FMT_ARGS=()
+if [ "$JSON_MODE" = "1" ]; then
+    PHPSTAN_FMT_ARGS=(--error-format=json --no-progress)
+fi
+
 # Run from the extension directory so that any relative paths in the extension's
 # own phpstan.neon resolve correctly, regardless of where the user invoked the script.
 # If the extension provides its own neon config (with paths), let PHPStan use those.
 # Otherwise fall back to scanning the entire extension directory.
 if [ -f "$EXTENSION_DIR/phpstan.neon" ] || [ -f "$EXTENSION_DIR/phpstan.neon.dist" ]; then
-    (cd "$EXTENSION_DIR" && ${VENDOR_BIN}phpstan analyse --memory-limit=4G -c "$RUNTIME_NEON")
+    (cd "$EXTENSION_DIR" && ${VENDOR_BIN}phpstan analyse --memory-limit=4G -c "$RUNTIME_NEON" "${PHPSTAN_FMT_ARGS[@]}")
 else
-    (cd "$EXTENSION_DIR" && ${VENDOR_BIN}phpstan analyse --memory-limit=4G -c "$RUNTIME_NEON" "$EXTENSION_DIR")
+    (cd "$EXTENSION_DIR" && ${VENDOR_BIN}phpstan analyse --memory-limit=4G -c "$RUNTIME_NEON" "${PHPSTAN_FMT_ARGS[@]}" "$EXTENSION_DIR")
 fi

--- a/bin/magento2-lint
+++ b/bin/magento2-lint
@@ -2,11 +2,19 @@
 
 set -e
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+# shellcheck source=../lib/parse-args.sh
+source "$SCRIPT_DIR/../lib/parse-args.sh"
+
 EXTENSION_DIR=${1?Error: no extension dir given}
 VENDOR_BIN=${2}
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck source=../lib/env.sh
 source "$SCRIPT_DIR/../lib/env.sh"
 
-${VENDOR_BIN}php-cs-fixer fix --allow-risky=yes "$EXTENSION_DIR"
+PHPCS_FIXER_FMT_ARGS=()
+if [ "$JSON_MODE" = "1" ]; then
+    PHPCS_FIXER_FMT_ARGS=(--format=json)
+fi
+
+${VENDOR_BIN}php-cs-fixer fix --allow-risky=yes "${PHPCS_FIXER_FMT_ARGS[@]}" "$EXTENSION_DIR"

--- a/bin/magento2-php-compatibility
+++ b/bin/magento2-php-compatibility
@@ -2,10 +2,13 @@
 
 set -e
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+# shellcheck source=../lib/parse-args.sh
+source "$SCRIPT_DIR/../lib/parse-args.sh"
+
 EXTENSION_DIR=${1?Error: no extension dir given}
 VENDOR_BIN=${2}
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck source=../lib/env.sh
 source "$SCRIPT_DIR/../lib/env.sh"
 
@@ -15,6 +18,12 @@ if [ ! -d "$PHP_COMPATIBILITY_PATH" ]; then
   PHP_COMPATIBILITY_PATH=$BIN_DIR/../phpcompatibility/php-compatibility
 fi
 
-${VENDOR_BIN}phpcs --config-set installed_paths $PHP_COMPATIBILITY_PATH
-
-${VENDOR_BIN}phpcs -p --standard=PHPCompatibility --runtime-set testVersion 7.4- --runtime-set ignore_warnings_on_exit true --ignore=vendor/*,*/view "$EXTENSION_DIR"
+if [ "$JSON_MODE" = "1" ]; then
+    # `--config-set` prints "Using config file: ..." to stdout; keep it off the
+    # JSON stream. Drop `-p` (progress dots) and select the JSON reporter.
+    ${VENDOR_BIN}phpcs --config-set installed_paths $PHP_COMPATIBILITY_PATH 1>&2
+    ${VENDOR_BIN}phpcs --report=json --standard=PHPCompatibility --runtime-set testVersion 7.4- --runtime-set ignore_warnings_on_exit true --ignore=vendor/*,*/view "$EXTENSION_DIR"
+else
+    ${VENDOR_BIN}phpcs --config-set installed_paths $PHP_COMPATIBILITY_PATH
+    ${VENDOR_BIN}phpcs -p --standard=PHPCompatibility --runtime-set testVersion 7.4- --runtime-set ignore_warnings_on_exit true --ignore=vendor/*,*/view "$EXTENSION_DIR"
+fi

--- a/bin/magento2-test
+++ b/bin/magento2-test
@@ -2,27 +2,82 @@
 
 set -e
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+# shellcheck source=../lib/parse-args.sh
+source "$SCRIPT_DIR/../lib/parse-args.sh"
+
 EXTENSION_DIR=${1?Error: no extension dir given}
 VENDOR_BIN=${2}
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck source=../lib/env.sh
 source "$SCRIPT_DIR/../lib/env.sh"
 
 GREEN='\033[0;32m'
 NC='\033[0m' # No Color
 
-printf "\n1. Analysing ${GREEN}Coding Style${NC} \n\n"
-
-${VENDOR_BIN}php-cs-fixer fix --allow-risky=yes "$EXTENSION_DIR" --dry-run
-
-printf "\n2. Analysing ${GREEN}PHP Compatibility${NC} \n\n"
-
 PHP_COMPATIBILITY_PATH=$BIN_DIR/../../../vendor/phpcompatibility/php-compatibility
 
 if [ ! -d "$PHP_COMPATIBILITY_PATH" ]; then
   PHP_COMPATIBILITY_PATH=$BIN_DIR/../../../phpcompatibility/php-compatibility
 fi
+
+if [ "$JSON_MODE" = "1" ]; then
+    # Aggregated JSON mode: run all three checks regardless of individual failures,
+    # capture each tool's stdout, then emit a single JSON document.
+    set +e
+
+    coding_style_out=$(${VENDOR_BIN}php-cs-fixer fix --allow-risky=yes --dry-run --format=json "$EXTENSION_DIR")
+    coding_style_exit=$?
+
+    ${VENDOR_BIN}phpcs --config-set installed_paths "$PHP_COMPATIBILITY_PATH" 1>&2
+    php_compat_out=$(${VENDOR_BIN}phpcs --report=json --standard=PHPCompatibility --runtime-set testVersion 7.4- --runtime-set ignore_warnings_on_exit true --ignore=vendor/*,*/view "$EXTENSION_DIR")
+    php_compat_exit=$?
+
+    static_analysis_out=$("$BIN_DIR/magento2-analyse" --json "$EXTENSION_DIR" "$VENDOR_BIN")
+    static_analysis_exit=$?
+
+    # Fall back to a stub error object if a tool produced no parseable JSON
+    # (e.g. died before reaching its reporter).
+    is_json() {
+        [ -n "$1" ] || return 1
+        local first=${1:0:1}
+        [ "$first" = "{" ] || [ "$first" = "[" ]
+    }
+
+    if ! is_json "$coding_style_out"; then
+        coding_style_out="{\"error\":\"no JSON emitted\",\"exit_code\":$coding_style_exit}"
+    fi
+    if ! is_json "$php_compat_out"; then
+        php_compat_out="{\"error\":\"no JSON emitted\",\"exit_code\":$php_compat_exit}"
+    fi
+    if ! is_json "$static_analysis_out"; then
+        static_analysis_out="{\"error\":\"no JSON emitted\",\"exit_code\":$static_analysis_exit}"
+    fi
+
+    cat <<EOF
+{
+  "coding_style": $coding_style_out,
+  "php_compatibility": $php_compat_out,
+  "static_analysis": $static_analysis_out,
+  "exit_codes": {
+    "coding_style": $coding_style_exit,
+    "php_compatibility": $php_compat_exit,
+    "static_analysis": $static_analysis_exit
+  }
+}
+EOF
+
+    overall=$coding_style_exit
+    [ "$php_compat_exit" -gt "$overall" ] && overall=$php_compat_exit
+    [ "$static_analysis_exit" -gt "$overall" ] && overall=$static_analysis_exit
+    exit $overall
+fi
+
+printf "\n1. Analysing ${GREEN}Coding Style${NC} \n\n"
+
+${VENDOR_BIN}php-cs-fixer fix --allow-risky=yes "$EXTENSION_DIR" --dry-run
+
+printf "\n2. Analysing ${GREEN}PHP Compatibility${NC} \n\n"
 
 ${VENDOR_BIN}phpcs --config-set installed_paths $PHP_COMPATIBILITY_PATH
 

--- a/lib/env.sh
+++ b/lib/env.sh
@@ -33,6 +33,10 @@ fi
 # Guard against running the update check twice when scripts delegate to each other
 # (e.g. magento2-test calling magento2-analyse).
 if [ -z "$MAGENTO2_TOOLS_ENV_LOADED" ]; then
-    "$BIN_DIR/magento2-update"
+    if [ "$JSON_MODE" = "1" ]; then
+        "$BIN_DIR/magento2-update" 1>&2
+    else
+        "$BIN_DIR/magento2-update"
+    fi
     export MAGENTO2_TOOLS_ENV_LOADED=1
 fi

--- a/lib/parse-args.sh
+++ b/lib/parse-args.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Parse magento2-tools wrapper flags out of the caller's positional args.
+#
+# Recognised flags:
+#   --json    Switch the script into machine-readable JSON output mode.
+#             Wrapper banners and progress messages get routed to stderr,
+#             and the underlying tool is invoked with its native JSON
+#             formatter so stdout is a single well-formed JSON document.
+#
+# Source this BEFORE assigning $1/$2 so that EXTENSION_DIR / VENDOR_BIN
+# continue to read positional args without the flag in the way.
+#
+# JSON_MODE is exported so delegated invocations (e.g. magento2-test calling
+# magento2-analyse) inherit the mode without needing to re-pass --json.
+
+JSON_MODE=${JSON_MODE:-0}
+_pa_new=()
+for _pa_arg in "$@"; do
+    if [ "$_pa_arg" = "--json" ]; then
+        JSON_MODE=1
+    else
+        _pa_new+=("$_pa_arg")
+    fi
+done
+set -- "${_pa_new[@]}"
+export JSON_MODE
+unset _pa_new _pa_arg


### PR DESCRIPTION
## Summary
> [!NOTE]
> Stacked on earlier false positive fix PR https://github.com/algolia/magento2-tools/pull/12
 
Adds a consistent `--json` flag to every bin script so CI/CD pipelines and AI agents can consume structured output instead of scraping human-readable text.

- New [lib/parse-args.sh](https://www.notion.so/lib/parse-args.sh) strips `-json` out of `$@` and exports `JSON_MODE` so positional args (`EXTENSION_DIR`, `VENDOR_BIN`) and delegated invocations (e.g. `magento2-test` to `magento2-analyse`) keep working unchanged.
- Underlying tools' native JSON reporters are used: PHPStan `-error-format=json --no-progress`, php-cs-fixer `-format=json`, phpcs `-report=json` (drops `p` progress).
- Wrapper banners, "Magento root detected" messages, `phpcs --config-set` chatter, and `magento2-update` notifications are all routed to stderr in JSON mode so stdout stays a single well-formed JSON document.
- [bin/magento2-test](https://www.notion.so/bin/magento2-test) aggregates all three tools into one document (`coding_style`, `php_compatibility`, `static_analysis`, `exit_codes`); all three checks always run, exit code is the max of the three.

## Usage

```bash
magento2-analyse --json /path/to/ext | jq '.files'
magento2-lint --json /path/to/ext | jq .
magento2-php-compatibility --json /path/to/ext | jq '.totals'
magento2-test --json /path/to/ext | jq '.exit_codes'
```

## Behavioral contract

| Mode | stdout | stderr | Exit code |
| --- | --- | --- | --- |
| default (no flag) | tool output + banners (unchanged) | tool errors | tool exit code |
| `--json` single tool | strict JSON document | banners, errors, update notices | tool exit code |
| `--json` on `magento2-test` | one aggregated JSON object | suppressed banners + tool stderr | max of three exit codes |

Stdout in `--json` mode is always a single JSON document parseable by `jq .`.

The flag is positional-agnostic: `magento2-analyse --json /ext` and `magento2-analyse /ext --json` both work.

## Compatibility

No breaking changes for existing callers. Without `--json` the scripts behave identically to before, with one minor improvement: detection-failure messages in `magento2-analyse` now go to stderr instead of stdout (they were always errors).